### PR TITLE
Update software stack

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,7 +18,7 @@ jobs:
         target-image: ["intel-impi-image", "gnu-ompi-image"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
@@ -41,7 +41,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/kmturbulenz/${{ matrix.target-image }}
@@ -50,14 +50,14 @@ jobs:
           type=ref,event=tag
           type=sha
 
-    - uses: docker/login-action@v2
+    - uses: docker/login-action@v3
       name: Login to Github Packages
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: docker/build-push-action@v3
+    - uses: docker/build-push-action@v4
       name: Build image and push to GitHub Container Registry
       with:
         context: .

--- a/build-hdf5.sh
+++ b/build-hdf5.sh
@@ -21,9 +21,11 @@ cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX=$HDF5_ROOT_DIR/install \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DHDF5_BUILD_FORTRAN=ON \
     -DBUILD_TESTING=OFF \
+    -DONLY_SHARED_LIBS=ON \
+    -DHDF5_BUILD_FORTRAN=ON \
     -DHDF5_ENABLE_Z_LIB_SUPPORT=OFF \
+    -DHDF5_ENABLE_SZIP_SUPPORT=OFF \
     -DHDF5_ENABLE_PARALLEL=ON \
     -DHDF5_ENABLE_TRACE=ON \
     -DHDF5_ENABLE_DEPRECATED_SYMBOLS=OFF \
@@ -31,3 +33,11 @@ cmake \
     -DHDF5_BUILD_HL_LIB=OFF \
     ../source 2>&1 | tee cmake.log
 ninja install 2>&1 | tee ninja.log
+
+# Remove '-shared' suffix from HDF5 tool names
+# https://forum.hdfgroup.org/t/tools-have-static-linking-when-built-with-cmake/11926
+cd $HDF5_ROOT_DIR/install/bin
+for i in *-shared; do
+    mv $i ${i%-shared}
+done
+cd -

--- a/build-openmpi.sh
+++ b/build-openmpi.sh
@@ -24,5 +24,7 @@ cd source
     --with-pmix=internal \
     --disable-oshmem \
     --with-ucx \
+    --with-psm2 \
+    --with-libfabric \
     2>&1 | tee configure.log
 make -j install 2>&1 | tee make.log


### PR DESCRIPTION
Changed from Centos 7 to Oracle Linux 8

 - Intel compilers 2024.0
 - Intel MPI 2021.11
 - GCC compilers 13.1
 - OpenMPI 4.1.6
 - HDF5 1.14.0
 - Ninja to 1.11.1