### PR TITLE
Update build images

### DIFF
--- a/.github/workflows/build-single-image.yml
+++ b/.github/workflows/build-single-image.yml
@@ -36,7 +36,7 @@ jobs:
 
     name: Build ${{ inputs.image }}
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 360
 
     steps:
     - uses: actions/checkout@v6

--- a/HDF5-NAG-Disable-threads.patch
+++ b/HDF5-NAG-Disable-threads.patch
@@ -1,0 +1,12 @@
+--- CMakeLists-0.txt	2025-11-11 01:00:49.000000000 +0100
++++ CMakeLists.txt	2026-01-13 09:26:10.556920528 +0100
+@@ -839,7 +839,8 @@
+ 
+ # Determine if a threading package is available on this system
+ set (THREADS_PREFER_PTHREAD_FLAG ON)
+-find_package (Threads)
++#find_package (Threads)
++set(Threads_FOUND FALSE)
+ if (Threads_FOUND)
+   set (H5_HAVE_THREADS 1)
+   set (CMAKE_REQUIRED_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})

--- a/build-hdf5.sh
+++ b/build-hdf5.sh
@@ -4,7 +4,7 @@
 set -o errexit
 set -o pipefail
 
-HDF5_URL="https://github.com/HDFGroup/hdf5/releases/download/hdf5_${HDF5_VER//-/.}/hdf5-${HDF5_VER}.tar.gz"
+HDF5_URL="https://github.com/HDFGroup/hdf5/releases/download/${HDF5_VER}/hdf5-${HDF5_VER}.tar.gz"
 HDF5_ROOT_DIR="/opt/hdf5/${HDF5_VER}"
 
 mkdir -p $HDF5_ROOT_DIR
@@ -19,8 +19,9 @@ mv hdf5-$HDF5_VER source
 # $NAG_ROOT is set
 if [ -n "$NAG_ROOT" ]; then
     # NAG Fortran compiler + CMake require you to use the MPI compiler wrappers
-    FC="mpifort"
-    CC="mpicc"
+    export FC="mpifort"
+    export CC="mpicc"
+    patch source/CMakeLists.txt /opt/HDF5-NAG-Disable-threads.patch
 fi
 
 mkdir build
@@ -30,9 +31,9 @@ cmake \
     -DCMAKE_INSTALL_PREFIX=$HDF5_ROOT_DIR/install \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DBUILD_TESTING=OFF \
-    -DONLY_SHARED_LIBS=ON \
+    -DBUILD_STATIC_LIBS=OFF \
     -DHDF5_BUILD_FORTRAN=ON \
-    -DHDF5_ENABLE_Z_LIB_SUPPORT=OFF \
+    -DHDF5_ENABLE_ZLIB_SUPPORT=OFF \
     -DHDF5_ENABLE_SZIP_SUPPORT=OFF \
     -DHDF5_ENABLE_PARALLEL=ON \
     -DHDF5_ENABLE_TRACE=ON \

--- a/build-imb.sh
+++ b/build-imb.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Fetch and build Intel MPI benchmarks
+# This script require environment variable IMB_VER to be set
+set -o errexit
+set -o pipefail
+
+IMB_ROOT_DIR="/opt/imb"
+IMB_BIN_DIR="/opt/imb/bin"
+
+IMP_URL="https://github.com/intel/mpi-benchmarks/archive/refs/tags/IMB-v${IMB_VER}.tar.gz"
+
+mkdir -p $IMB_ROOT_DIR/licenses
+mkdir -p $IMB_BIN_DIR
+cd $IMB_ROOT_DIR
+
+wget --no-verbose $IMP_URL
+tar -xf IMB-v${IMB_VER}.tar.gz
+rm IMB-v${IMB_VER}.tar.gz
+
+cd mpi-benchmarks-IMB-v${IMB_VER}
+cp license/license.txt $IMB_ROOT_DIR/licenses/LICENSE-IMB.txt
+
+cd src_c
+make
+cp IMB-EXT $IMB_BIN_DIR
+cp IMB-IO $IMB_BIN_DIR
+cp IMB-MPI1 $IMB_BIN_DIR
+cp IMB-NBC $IMB_BIN_DIR
+cp IMB-RMA $IMB_BIN_DIR
+
+cd P2P
+make
+cp IMB-P2P $IMB_BIN_DIR

--- a/build-llvm.sh
+++ b/build-llvm.sh
@@ -15,7 +15,8 @@ cd build
 cmake -GNinja \
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_PREFIX="$LLVM_ROOT_DIR/install" \
-    -DLLVM_ENABLE_PROJECTS="clang;lld;flang;openmp" \
+    -DLLVM_ENABLE_PROJECTS="clang;lld;flang" \
+    -DLLVM_ENABLE_RUNTIMES="compiler-rt;openmp;flang-rt" \
     -DLLVM_TARGETS_TO_BUILD="X86" \
     -DLLVM_ENABLE_RTTI="ON" \
     ../llvm 2>&1 | tee cmake.log

--- a/build-openmpi.sh
+++ b/build-openmpi.sh
@@ -19,6 +19,7 @@ mkdir install
 cd source
 ./configure \
     --prefix=$OMPI_ROOT_DIR/install \
+    --enable-mca-dso \
     --with-hwloc=internal \
     --with-libevent=internal \
     --with-pmix=internal \


### PR DESCRIPTION
 - Update Intel MPI to version 2021.17
 - Update to most recent compilers
 - Add IMB (Intel MPI Benchmarks)
 - Update to HDF5 2.0.0