### PR TITLE
Switch MPICH from UCX to OFI

### DIFF
--- a/build-mpich.sh
+++ b/build-mpich.sh
@@ -22,7 +22,7 @@ cd source
     --prefix=$MPICH_ROOT_DIR/install \
     --disable-static \
     --with-pic \
-    --with-device=ch4:ucx \
+    --with-device=ch4:ofi \
     2>&1 | tee configure.log
 make -j install 2>&1 | tee make.log
 


### PR DESCRIPTION
Fixes this issue with UCX in some testcases:

```
[kmt-trd-2:1185926:0:1185926] Caught signal 8 (Floating point exception: integer divide by zero) ==== backtrace (tid:1185926) ====
 0  /opt/llvm/mpich/mpich-4.3.2/install/lib/libucs.so.0(+0x32b64) [0x714f9d4d8b64]
 1  /opt/llvm/mpich/mpich-4.3.2/install/lib/libucs.so.0(+0x31eca) [0x714f9d4d7eca]
 2  /lib/x86_64-linux-gnu/libc.so.6(+0x45330) [0x714f9ce45330]
 3  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(+0x15f2a8) [0x714f9dd5f2a8]
 4  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(+0x15e3e9) [0x714f9dd5e3e9]
 5  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(+0x15ddb2) [0x714f9dd5ddb2]
 6  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(+0x15d721) [0x714f9dd5d721]
 7  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(+0x15c635) [0x714f9dd5c635]
 8  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpi.so.12(MPI_Irecv+0x43) [0x714f9dd5b9f3]
 9  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpifort.so.12(+0xeabad) [0x714f9eceabad]
10  /opt/llvm/mpich/mpich-4.3.2/install/lib/libmpifort.so.12(mpi_irecv_f08ts_+0xf4) [0x714f9ec95884] 11  ../../src/mglet(+0x18080b) [0x57743ac0180b]
12  ../../src/mglet(+0x17ffd0) [0x57743ac00fd0]
13  ../../src/mglet(+0x179bf5) [0x57743abfabf5]
14  ../../src/mglet(+0x175a2e) [0x57743abf6a2e]
15  ../../src/mglet(+0x6a8065) [0x57743b129065]
16  ../../src/mglet(+0x14cfb1) [0x57743abcdfb1]
17  ../../src/mglet(+0x14d00d) [0x57743abce00d]
18  /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca) [0x714f9ce2a1ca] 19  /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x714f9ce2a28b] 20  ../../src/mglet(+0x14cd05) [0x57743abcdd05]
=================================
```

Since the configurations (llvm, nag) that use MPICh hare mostly for debugging purposes the choice of network interconnect currently does not matter on these platforms.